### PR TITLE
fix: possible invalid html markdown parser output

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/node": "^10.5.2",
     "@types/prismjs": "^1.9.0",
+    "@types/sanitize-html": "^2.5.0",
     "fs-extra": "^6.0.1",
     "np": "^7.4.0",
     "rimraf": "^2.6.2",
@@ -38,6 +39,7 @@
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-sanitizer": "https://github.com/huukimit/markdown-it-sanitizer#33dd3f7",
     "prismjs": "^1.15.0",
+    "sanitize-html": "^2.5.2",
     "twemoji": "^11.2.0"
   }
 }

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -1,6 +1,7 @@
 import twemoji from 'twemoji/2/esm';
 import Markdown = require('markdown-it');
 import emoji = require('markdown-it-emoji');
+import * as sanitizeHtml from 'sanitize-html';
 import sanitize = require('markdown-it-sanitizer');
 
 import katex from './plugins/katex/katex';
@@ -43,6 +44,11 @@ const defaultOptions: Options = {
         maxExpand: 100,
         maxCharacter: 1000,
     },
+};
+
+const sanitizeOptions: sanitizeHtml.IOptions = {
+    allowedTags: false,
+    allowedAttributes: false
 };
 
 export function createRenderer(options: Options) {
@@ -92,6 +98,11 @@ export function createRenderer(options: Options) {
     }
 
     md.use(sanitize, { align: true });
+
+    const originalRender = md.render;
+    md.render = (markdownContent) => {
+        return sanitizeHtml(originalRender.call(md, markdownContent), sanitizeOptions);
+    };
 
     return md;
 }


### PR DESCRIPTION
This PR adds `sanitize-html` package for validating and fixing any invalid HTML in markdown-it output.

`markdown-it-sanitizer` will still be kept, because as a plugin, it can sanitize on each and every `html_block` and `html_inline` tokens separately, while doesn't break HTML added by other plugins.

Because `markdown-it-sanitizer` processes sanitizing on token level, it cannot possibly correct every invalid HTML. `sanitize-html` works on whole HTML output and is used for cleaning invalid HTML (for example, missing end tags). All sanitizing features of `sanitize-html` are disabled (by setting `allowedTags` and `allowedAttributes` to `false`).

### What it does

Missing end tags get added:
`<div>test` => `<div>test</div>`

Wrong end tag positions are corrected:
`<li><div>test 3</li></div>` => `<li><div>test 3</div></li>`

Original invalid output from user is fixed:
```html
<h3>II) InkWell</h3>
<ul>
<li>Theo như mình biết thì thằng này thường dùng khi ripple effect chỉ loay hoay theo dạng rectangle thì phải (dạng rectangle splash)</li>
<li>Nếu đơn giản chỉ là một hiệu ứng gợn sóng khi click button thì bạn có thể dùng thằng này.
<div align="center"><br>
<img src="https://images.viblo.asia/9422ba67-3335-455c-9755-7c55f3ffd44d.gif" alt="" data-src="https://images.viblo.asia/9422ba67-3335-455c-9755-7c55f3ffd44d.gif" data-zoom-src="https://images.viblo.asia/9422ba67-3335-455c-9755-7c55f3ffd44d.gif" srcset="https://images.viblo.asia/9422ba67-3335-455c-9755-7c55f3ffd44d.gif" class="article-img">
<img src="https://images.viblo.asia/5814b3a1-c770-4588-8356-98459aa1c73b.gif" alt="" data-src="https://images.viblo.asia/5814b3a1-c770-4588-8356-98459aa1c73b.gif" data-zoom-src="https://images.viblo.asia/5814b3a1-c770-4588-8356-98459aa1c73b.gif" srcset="https://images.viblo.asia/5814b3a1-c770-4588-8356-98459aa1c73b.gif" class="article-img"></li>
</ul>
</div>
- Click vào hình ảnh để thấy được effect =))
```
=> (`</div>` is moved to before `</li>`)
```html
<h3>II) InkWell</h3>
<ul>
<li>Theo như mình biết thì thằng này thường dùng khi ripple effect chỉ loay hoay theo dạng rectangle thì phải (dạng rectangle splash)</li>
<li>Nếu đơn giản chỉ là một hiệu ứng gợn sóng khi click button thì bạn có thể dùng thằng này.
<div align="center"><br />
<img src="https://images.viblo.asia/9422ba67-3335-455c-9755-7c55f3ffd44d.gif" alt data-src="https://images.viblo.asia/9422ba67-3335-455c-9755-7c55f3ffd44d.gif" data-zoom-src="https://images.viblo.asia/9422ba67-3335-455c-9755-7c55f3ffd44d.gif" srcset="https://images.viblo.asia/9422ba67-3335-455c-9755-7c55f3ffd44d.gif" class="article-img" />
<img src="https://images.viblo.asia/5814b3a1-c770-4588-8356-98459aa1c73b.gif" alt data-src="https://images.viblo.asia/5814b3a1-c770-4588-8356-98459aa1c73b.gif" data-zoom-src="https://images.viblo.asia/5814b3a1-c770-4588-8356-98459aa1c73b.gif" srcset="https://images.viblo.asia/5814b3a1-c770-4588-8356-98459aa1c73b.gif" class="article-img" /></div></li>
</ul>
- Click vào hình ảnh để thấy được effect =))
```
