### PR TITLE
fix: Unable to access huukimit/markdown-it-santinizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash.escape": "^4.0.1",
     "markdown-it": "^8.4.2",
     "markdown-it-emoji": "^1.4.0",
-    "markdown-it-sanitizer": "https://github.com/huukimit/markdown-it-sanitizer#33dd3f7",
+    "markdown-it-sanitizer": "https://github.com/viblo-asia/markdown-it-sanitizer#33dd3f7",
     "prismjs": "^1.15.0",
     "sanitize-html": "^2.5.2",
     "twemoji": "14.0.2"


### PR DESCRIPTION
```bash
fatal: unable to access 'https://github.com/huukimit/markdown-it-sanitizer/': Could not resolve host: github.com
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```